### PR TITLE
Include category key

### DIFF
--- a/gears/ANTs/buildtemplateparallel/manifest.json
+++ b/gears/ANTs/buildtemplateparallel/manifest.json
@@ -15,7 +15,8 @@
             "suite": "ANTs"
         },
         "gear-builder": {
-            "image": "matherlab/ants-buildtemplateparallel:1.0.0"
+            "image": "matherlab/ants-buildtemplateparallel:1.0.0",
+	    "category": "analysis"
         }
     },
     "config": {


### PR DESCRIPTION
The `gear-builder.category` key tells the CLI during upload to set this as an analysis gear.